### PR TITLE
Fixed FHIR deploy script app roles assignment

### DIFF
--- a/scripts/deployfhirproxy.bash
+++ b/scripts/deployfhirproxy.bash
@@ -50,6 +50,7 @@ declare preprocessors=""
 declare postprocessors=""
 declare msi=""
 declare tags="HealthArchitectures-Solutions=FHIR-Proxy"
+declare script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 function fail {
   echo $1 >&2
@@ -297,7 +298,7 @@ echo "Starting Secure FHIR Proxy deployment..."
 		echo "Configuring reply urls for app..."
 		stepresult=$(az ad app update --id $spappid --reply-urls $spreplyurls)
 		echo "Adding FHIR Custom Roles to Manifest..."
-		stepresult=$(az ad app update --id $spappid --app-roles @fhirroles.json)
+		stepresult=$(az ad app update --id $spappid --app-roles @${script_dir}/fhirroles.json)
 		echo "Enabling AAD Authorization and Securing the FHIR Proxy"
 		stepresult=$(az webapp auth update -g $resourceGroupName -n $faname --enabled true --action AllowAnonymous --aad-allowed-token-audiences $fahost --aad-client-id $spappid --aad-client-secret $spsecret --aad-token-issuer-url $tokeniss)
 		echo "Starting fhir proxy function app..."


### PR DESCRIPTION
Resolves issue #6 .

FHIR deployment script expected `fhirroles.json` to be in the same directory that the user invoked the script from.
Changed this to expect the file in the script directory by using bash to store the current script directory.

Tested on bash 5 on OS X 11.4.