### PR TITLE
upgraded to azure function v4/dotnet6

### DIFF
--- a/FHIRProxy/FHIRProxy.csproj
+++ b/FHIRProxy/FHIRProxy.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	<TargetFramework>netcoreapp3.1</TargetFramework>
-	<AzureFunctionsVersion>v3</AzureFunctionsVersion>
+	<TargetFramework>net6.0</TargetFramework>
+	<AzureFunctionsVersion>v4</AzureFunctionsVersion>
   <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
 	<Version>2020.10.30.1</Version>
 	<Authors>Microsoft Health Next Smokejumpers</Authors>
@@ -20,14 +20,14 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.2.0" />
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.1.2" />
+	<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="5.0.1" />
+	<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.5.1" />
     <PackageReference Include="Hl7.Fhir.Specification.R4" Version="2.0.3" />
     <PackageReference Include="LazyCache" Version="2.1.2" />
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.8" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.3" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.1" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.0" />
     <PackageReference Include="Polly" Version="7.2.2" />
     <PackageReference Include="StackExchange.Redis" Version="2.2.4" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.8.0" />


### PR DESCRIPTION
We recently started using fhir-proxy and due to the upcoming support end for v3 azure function as stated below we have upgraded it to azure function version4/dotnet6.

_Issue: On 3 December 2022, extended support for Microsoft .NET Core 3.1 will end. After that date, your applications that are hosted on Functions will continue to run, but we'll no longer provide patches or customer service for .NET Core 3.1. Update your Functions applications to runtime version 4.x, which uses .NET 6._