### PR TITLE
Enable use of Managed Service Identity

### DIFF
--- a/FHIRProxy/ADUtils.cs
+++ b/FHIRProxy/ADUtils.cs
@@ -59,7 +59,7 @@ namespace FHIRProxy
         
         public static bool isMSI(string resource, string tenant = null, string clientid = null, string secret = null)
         {
-            return (!string.IsNullOrEmpty(resource) && (string.IsNullOrEmpty(tenant) && string.IsNullOrEmpty(clientid) && string.IsNullOrEmpty(secret)));
+            return (!string.IsNullOrEmpty(resource) && (!string.IsNullOrEmpty(tenant) && string.IsNullOrEmpty(clientid) && string.IsNullOrEmpty(secret)));
         }
     }
 }


### PR DESCRIPTION
Enable the use of a Managed Service Identity to access the FHIR server, rather than client ID and secret. Only one very simple change was required to make this work, allowing the specification of the tenant ID.

I did test this by:
1. Setting FS-RESROUCE, FS-TENANT and FS-URL application configuration settings on the function app. Do not set the other FS-* settings.
2. Granting the function app's managed identity a data place role on the FHIR server.
3. Accessing the metadata endpoint via the proxy function app.