### PR TITLE
Added group export with resources not in the patient compartment 

### DIFF
--- a/FHIRProxy/ExportAggregate.cs
+++ b/FHIRProxy/ExportAggregate.cs
@@ -1,0 +1,32 @@
+﻿
+using Microsoft.WindowsAzure.Storage.Table;
+using StackExchange.Redis;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace FHIRProxy
+{
+    public class ExportAggregate : TableEntity
+    {
+        public ExportAggregate()
+        {
+
+        }
+        public ExportAggregate(List<string> childContentLocationUrls)
+        {
+            this.PartitionKey = "exportaggregate";
+            this.RowKey = Guid.NewGuid().ToString();
+        }
+        public string ExportId {
+            get { return this.RowKey; }
+        }
+
+        public List<string> ExportUrlList => ExportUrls.Split(",").ToList();
+
+
+        public string ExportUrls { get; set; }
+    }
+}

--- a/FHIRProxy/ExportAggregate.cs
+++ b/FHIRProxy/ExportAggregate.cs
@@ -15,14 +15,16 @@ namespace FHIRProxy
         {
 
         }
-        public ExportAggregate(List<string> childContentLocationUrls)
+        public ExportAggregate(string exportRequestUrl, List<string> childContentLocationUrls)
         {
-            this.PartitionKey = "exportaggregate";
-            this.RowKey = Guid.NewGuid().ToString();
+            PartitionKey = "exportaggregate";
+            RowKey = Guid.NewGuid().ToString();
+            ExportRequestUrl = exportRequestUrl;
+            ExportUrls = string.Join(",", childContentLocationUrls);
         }
-        public string ExportId {
-            get { return this.RowKey; }
-        }
+        public string ExportId => RowKey;
+
+        public string ExportRequestUrl { get; set; }
 
         public List<string> ExportUrlList => ExportUrls.Split(",").ToList();
 

--- a/FHIRProxy/ProxyConstants.cs
+++ b/FHIRProxy/ProxyConstants.cs
@@ -11,5 +11,6 @@ namespace FHIRProxy
         public const string FEDERATED_APP_TABLE = "fedappregistrations";
         public const string IDENTITY_LINKS_TABLE = "identitylinks";
         public const string SCOPE_STORE_TABLE = "scopestore";
+        public const string EXPORT_AGGREGATE_TABLE = "exportaggregate";
     }
 }

--- a/FHIRProxy/postprocessors/ONCExportPostProcess.cs
+++ b/FHIRProxy/postprocessors/ONCExportPostProcess.cs
@@ -38,7 +38,7 @@ namespace FHIRProxy.postprocessors
             await Task.Delay(0);
             if (req.Method.Equals("GET") && req.Path.HasValue)
             {
-                if (req.Path.Value.StartsWith("/fhir/_operations/export") || req.Path.Value.StartsWith("/fhir/_operations/aggexport"))
+                if (req.Path.Value.StartsWith("/fhir/_operations/export"))
                 {
                     ClaimsIdentity ci = (ClaimsIdentity)principal.Identity;
                     if (response.StatusCode==System.Net.HttpStatusCode.OK && response.Content != null)

--- a/FHIRProxy/postprocessors/ONCExportPostProcess.cs
+++ b/FHIRProxy/postprocessors/ONCExportPostProcess.cs
@@ -38,7 +38,7 @@ namespace FHIRProxy.postprocessors
             await Task.Delay(0);
             if (req.Method.Equals("GET") && req.Path.HasValue)
             {
-                if (req.Path.Value.StartsWith("/fhir/_operations/export"))
+                if (req.Path.Value.StartsWith("/fhir/_operations/export") || req.Path.Value.StartsWith("/fhir/_operations/aggexport"))
                 {
                     ClaimsIdentity ci = (ClaimsIdentity)principal.Identity;
                     if (response.StatusCode==System.Net.HttpStatusCode.OK && response.Content != null)

--- a/FHIRProxy/preprocessors/ONCExportPreProcess.cs
+++ b/FHIRProxy/preprocessors/ONCExportPreProcess.cs
@@ -92,7 +92,7 @@ namespace FHIRProxy.preprocessors
       
         public async Task<IEnumerable<string>> GetPatientIdsForGroupId(PathString requestPath, ILogger log)
         {
-            // Group id is right before $export
+            // Group id is right before $exportj
             var pathSplit = requestPath.Value.Split("/");
             string groupId = pathSplit[pathSplit.Length - 1];
 
@@ -157,7 +157,7 @@ namespace FHIRProxy.preprocessors
 
                 if (!groupResult.IsSuccess())
                 {
-                    log.LogWarning("Child export returned without success. {Path} {StatusCode} {Body}", path, groupResult.StatusCode, new JObject(groupResult.Content).ToString());
+                    log.LogWarning("Child export returned without success. {Path} {StatusCode} {Body}", path, groupResult.StatusCode, groupResult.Content);
                     return groupResult;
                 }
 
@@ -168,7 +168,7 @@ namespace FHIRProxy.preprocessors
                     content["error"] = "Content-Location header not found for export";
                     groupResult.Content = content;
 
-                    log.LogError("Child export returned without ContentLocationHeader. {Path} {StatusCode} {Body}", path, groupResult.StatusCode, new JObject(groupResult.Content).ToString());
+                    log.LogError("Child export returned without ContentLocationHeader. {Path} {StatusCode} {Body}", path, groupResult.StatusCode, groupResult.Content.ToString());
 
                     return groupResult;
                 }
@@ -207,7 +207,7 @@ namespace FHIRProxy.preprocessors
                 {
                     if (!currentResponse.IsSuccess())
                     {
-                        log.LogWarning("Child export operation returned unsucessful. {Path} {StatusCode} {Body}", uri.LocalPath, currentResponse.StatusCode, new JObject(currentResponse.Content).ToString());
+                        log.LogWarning("Child export operation returned unsucessful. {Path} {StatusCode} {Body}", uri.LocalPath, currentResponse.StatusCode, currentResponse.Content.ToString());
                     }
 
                     return currentResponse;

--- a/FHIRProxy/preprocessors/ONCExportPreProcess.cs
+++ b/FHIRProxy/preprocessors/ONCExportPreProcess.cs
@@ -70,7 +70,7 @@ namespace FHIRProxy.preprocessors
 
                     if (overrideExportUrls.Count > 0)
                     {
-                        FHIRResponse resp = await ProcessExportAggregate(req.GetEncodedUrl(), overrideExportUrls, req.Host, log);
+                        FHIRResponse resp = await ProcessExportAggregate(req.GetEncodedUrl(), overrideExportUrls, req.Host, req.Headers, log);
                         return new ProxyProcessResult(false, string.Empty, string.Empty, resp);
                     }
                 }
@@ -146,12 +146,12 @@ namespace FHIRProxy.preprocessors
             }
         }
 
-        public async Task<FHIRResponse> ProcessExportAggregate(string requestUrl, List<string> overrideExportUrls, HostString host, ILogger log)
+        public async Task<FHIRResponse> ProcessExportAggregate(string requestUrl, List<string> overrideExportUrls, HostString host, IHeaderDictionary reqHeaders, ILogger log)
         {
             List<string> exportContentLocations = new();
             foreach (var path in overrideExportUrls)
             {
-                FHIRResponse groupResult = await FHIRClient.CallFHIRServer(path, body: "", "GET", log);
+                FHIRResponse groupResult = await FHIRClient.CallFHIRServer(path, body: "", "GET", reqHeaders, log);
 
                 if (!groupResult.IsSuccess())
                 {

--- a/FHIRProxy/preprocessors/ONCExportPreProcess.cs
+++ b/FHIRProxy/preprocessors/ONCExportPreProcess.cs
@@ -54,6 +54,8 @@ namespace FHIRProxy.preprocessors
 
                     if (pp.ResourceType == "Group")
                     {
+                        log.LogInformation("Starting aggregate group export for group {GroupId}", pp.ResourceId);
+
                         // Handle device export
                         var patientsInGroup = await GetPatientIdsForGroupId(pp.ResourceId, log);
                         var deviceRequestStrings = BuildDeviceExportRequests(patientsInGroup, ci.ObjectId());

--- a/FHIRProxy/preprocessors/ONCExportPreProcess.cs
+++ b/FHIRProxy/preprocessors/ONCExportPreProcess.cs
@@ -118,7 +118,7 @@ namespace FHIRProxy.preprocessors
 
             int baseUrlLength = Utils.GetEnvironmentVariable("FS-URL", "").Length;
 
-            string baseDeviceRequest = $"$export?_container={oid}&_type=Device&_typefilter=";
+            string baseDeviceRequest = $"$export?_container={oid}&_type=Device&_typeFilter=";
             string currentRequestString = baseDeviceRequest;
 
             foreach (var typeFilter in patientIdsTypeFilters)

--- a/FHIRProxy/preprocessors/ONCExportPreProcess.cs
+++ b/FHIRProxy/preprocessors/ONCExportPreProcess.cs
@@ -102,10 +102,12 @@ namespace FHIRProxy.preprocessors
 
             var result = groupResult
                 .toJToken()
-                .SelectTokens("member[*].entity")
-                .Where(x => x.Value<string?>("reference") is not null)
-                .Where(x => x.Value<string?>("reference").Contains("Patient/"))
-                .Select(x => x.ToString().Split("/").Last())
+                .SelectTokens("member[*].entity.reference")
+                .Where(x => x is not null)
+                .Where(x => x is JValue)
+                .Select(x => x.ToString())
+                .Where(x => x.Contains("Patient/"))
+                .Select(x => x.Split("/").Last())
                 .ToList();
 
             log.LogInformation("Found patients {PatientIds} in group {GroupId}.", string.Join(",", result), groupId);

--- a/FHIRProxy/preprocessors/ONCExportPreProcess.cs
+++ b/FHIRProxy/preprocessors/ONCExportPreProcess.cs
@@ -61,20 +61,6 @@ namespace FHIRProxy.preprocessors
                         // Add current group export
                         overrideExportUrls.Add($"Group/{pp.ResourceId}/$export?_container={ci.ObjectId()}");
                     }
-                    else if (pp.ResourceType == "Patient")
-                    {
-                        log.LogInformation("Starting aggregate group export for patient {PatientId}", pp.ResourceId);
-                        var deviceRequestStrings = BuildDeviceExportRequests(new List<string> { pp.ResourceId }, ci.ObjectId());
-
-                        // Add system level export for all devices for patient
-                        overrideExportUrls.AddRange(deviceRequestStrings);
-
-                        // Add system level export for all reference data
-                        overrideExportUrls.Add($"$export?_container={ci.ObjectId()}&_type=Medication,Practitioner,Location,Organization");
-
-                        // Add current patient export
-                        overrideExportUrls.Add($"Patient/{pp.ResourceId}/$export?_container={ci.ObjectId()}");
-                    }
                     else
                     {
                         QueryString newquery = new QueryString();

--- a/FHIRProxy/preprocessors/ONCExportPreProcess.cs
+++ b/FHIRProxy/preprocessors/ONCExportPreProcess.cs
@@ -102,7 +102,7 @@ namespace FHIRProxy.preprocessors
 
             var result = groupResult
                 .toJToken()
-                .SelectTokens("member.entity")
+                .SelectTokens("member[*].entity")
                 .Where(x => x.Value<string?>("reference") is not null)
                 .Where(x => x.Value<string?>("reference").Contains("Patient/"))
                 .Select(x => x.ToString().Split("/").Last());

--- a/FHIRProxy/preprocessors/ONCExportPreProcess.cs
+++ b/FHIRProxy/preprocessors/ONCExportPreProcess.cs
@@ -100,7 +100,7 @@ namespace FHIRProxy.preprocessors
                     CloudTable eaTable = Utils.getTable(ProxyConstants.EXPORT_AGGREGATE_TABLE);
                     ExportAggregate ea = Utils.getEntity<ExportAggregate>(eaTable, ProxyConstants.EXPORT_AGGREGATE_TABLE, exportId);
 
-                    FHIRResponse resp = await FetchExportAggregateResult(ea, log);
+                    FHIRResponse resp = await FetchExportAggregateResult(ea, req.Host, log);
                     return new ProxyProcessResult(false, "", requestBody, resp);
                 }
             }
@@ -207,7 +207,7 @@ namespace FHIRProxy.preprocessors
             return resp;
         }
 
-        public async Task<FHIRResponse> FetchExportAggregateResult(ExportAggregate ea, ILogger log)
+        public async Task<FHIRResponse> FetchExportAggregateResult(ExportAggregate ea, HostString proxyHost, ILogger log)
         {
             JObject exportResult = new();
             exportResult["transactionTime"] = ea.Timestamp;
@@ -237,6 +237,8 @@ namespace FHIRProxy.preprocessors
 
                 foreach (JToken singleOutput in current.SelectTokens("output[*]"))
                 {
+                    Uri outputUrl = new(singleOutput["url"].ToString());
+                    singleOutput["url"] = $"https://{proxyHost.Value}/fhir/_exportFile{outputUrl.PathAndQuery}";
                     output.Add(singleOutput);
                 }
                 

--- a/FHIRProxy/preprocessors/ONCExportPreProcess.cs
+++ b/FHIRProxy/preprocessors/ONCExportPreProcess.cs
@@ -92,12 +92,12 @@ namespace FHIRProxy.preprocessors
             return new ProxyProcessResult(true, "", requestBody, null);
         }
       
-        public async Task<IEnumerable<string>> GetPatientIdsForGroupId(string groupId, ILogger log)
+        public async Task<List<string>> GetPatientIdsForGroupId(string groupId, ILogger log)
         {
             FHIRResponse groupResult = await FHIRClient.CallFHIRServer($"Group/{groupId}", body: "", "GET", log);
             if (groupResult.StatusCode != HttpStatusCode.OK)
             {
-                return Enumerable.Empty<string>();
+                return new List<string>();
             }
 
             var result = groupResult
@@ -105,7 +105,10 @@ namespace FHIRProxy.preprocessors
                 .SelectTokens("member[*].entity")
                 .Where(x => x.Value<string?>("reference") is not null)
                 .Where(x => x.Value<string?>("reference").Contains("Patient/"))
-                .Select(x => x.ToString().Split("/").Last());
+                .Select(x => x.ToString().Split("/").Last())
+                .ToList();
+
+            log.LogInformation("Found patients {PatientIds} in group {GroupId}.", string.Join(",", result), groupId);
 
             return result;
         }

--- a/FHIRProxy/preprocessors/ONCExportPreProcess.cs
+++ b/FHIRProxy/preprocessors/ONCExportPreProcess.cs
@@ -54,12 +54,8 @@ namespace FHIRProxy.preprocessors
 
                     if (pp.ResourceType == "Group")
                     {
-                        // Group id is right before $exportj
-                        var pathSplit = req.Path.Value.Split("/");
-                        string groupId = pathSplit[pathSplit.Length - 1];
-
                         // Handle device export
-                        var patientsInGroup = await GetPatientIdsForGroupId(groupId, log);
+                        var patientsInGroup = await GetPatientIdsForGroupId(pp.ResourceId, log);
                         var deviceRequestStrings = BuildDeviceExportRequests(patientsInGroup, ci.ObjectId());
 
                         // Add system level export for all devices for patients in group
@@ -69,7 +65,7 @@ namespace FHIRProxy.preprocessors
                         overrideExportUrls.Add($"$export?_container={ci.ObjectId()}&_type=Medication,Practitioner,Location,Organization");
 
                         // Add current group export
-                        overrideExportUrls.Add($"Group/{groupId}/$export?_container={ci.ObjectId()}");
+                        overrideExportUrls.Add($"Group/{pp.ResourceId}/$export?_container={ci.ObjectId()}");
                     }
 
                     if (overrideExportUrls.Count > 0)

--- a/FHIRProxy/preprocessors/ONCExportPreProcess.cs
+++ b/FHIRProxy/preprocessors/ONCExportPreProcess.cs
@@ -102,7 +102,7 @@ namespace FHIRProxy.preprocessors
 
             var result = groupResult
                 .toJToken()
-                .SelectToken("member.entity")
+                .SelectTokens("member.entity")
                 .Where(x => x.Value<string?>("reference") is not null)
                 .Where(x => x.Value<string?>("reference").Contains("Patient/"))
                 .Select(x => x.ToString().Split("/").Last());

--- a/FHIRProxy/preprocessors/ONCExportPreProcess.cs
+++ b/FHIRProxy/preprocessors/ONCExportPreProcess.cs
@@ -12,30 +12,26 @@
 * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
-using Azure.Core;
-using Azure;
+
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
+using System.Net;
+using System.Net.Http.Headers;
 using System.Security.Claims;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
-
+using System.Web;
+using Microsoft.WindowsAzure.Storage.Table;
 
 namespace FHIRProxy.preprocessors
 {
     class ONCExportPreProcess : IProxyPreProcess
     {
+        const int MAX_URL_LENGTH = 2048;
+
         public async Task<ProxyProcessResult> Process(string requestBody, HttpRequest req, ILogger log, ClaimsPrincipal principal)
         {
-            await Task.Delay(0);
             if (req.Method.Equals("GET") && req.Path.HasValue)
             {
                 if (req.Path.Value.EndsWith("$export"))
@@ -48,14 +44,114 @@ namespace FHIRProxy.preprocessors
                     }
                     newquery = newquery.Add("_container",ci.ObjectId());
                     req.QueryString = newquery;
-                   
-                }
-     
-            }
-            return new ProxyProcessResult(true, "", requestBody, null);
 
+                    FHIRParsedPath pp = req.parsePath();
+
+                    if (pp.ResourceType == "Group")
+                    {
+                        List<string> overrideExportUrls = new();
+
+                        // Handle device export
+                        var patientsInGroup = await GetPatientIdsForGroupId(req.Path, log);
+                        var deviceRequestStrings = BuildDeviceExportRequests(patientsInGroup, ci.ObjectId());
+
+                        // Add system level export for all devices for patients in group
+                        overrideExportUrls.AddRange(deviceRequestStrings);
+
+                        // Add system level export for all reference data
+                        overrideExportUrls.Add($"$export?_container={ci.ObjectId()}&_type=Medication,Practitioner,Location,Organization");
+
+                        // Add current group export
+                        overrideExportUrls.Add($"Group/$export?_container={ci.ObjectId()}");
+
+                        List<string> exportContentLocations = new();
+                        foreach (var path in overrideExportUrls)
+                        {
+                            FHIRResponse groupResult = await FHIRClient.CallFHIRServer(path, body: "", "GET", log);
+
+                            if (!groupResult.IsSuccess())
+                            {
+                                return new ProxyProcessResult(false, $"Bad return code {groupResult.StatusCode} for export.", string.Empty, groupResult);
+                            }
+
+                            if (!groupResult.Headers.ContainsKey("Content-Location"))
+                            {
+                                return new ProxyProcessResult(false, $"Content-Location header not found for export.", string.Empty, groupResult);
+                            }
+
+                            exportContentLocations.Add(groupResult.Headers["Content-Location"].Value);
+                        }
+
+                        ExportAggregate ea = new(exportContentLocations);
+
+                        CloudTable eaTable = Utils.getTable(ProxyConstants.EXPORT_AGGREGATE_TABLE);
+                        Utils.setEntity(eaTable, ea);
+
+                        FHIRResponse resp = new();
+                        resp.StatusCode = System.Net.HttpStatusCode.Accepted;
+                        resp.Headers.Add("Content-Location", new HeaderParm("Content-Location", $"https://{req.Host}/fhir/_operations/aggexport/{ea.ExportId}"));
+                        return new ProxyProcessResult(false, string.Empty, string.Empty, resp);
+                    }
+                }
+            }
+
+            return new ProxyProcessResult(true, "", requestBody, null);
         }
       
-       
+        public async Task<IEnumerable<string>> GetPatientIdsForGroupId(PathString requestPath, ILogger log)
+        {
+            // Group id is right before $export
+            var pathSplit = requestPath.Value.Split("/");
+            string groupId = pathSplit[pathSplit.Length - 1];
+
+            FHIRResponse groupResult = await FHIRClient.CallFHIRServer($"Group/{groupId}", body: "", "GET", log);
+            if (groupResult.StatusCode != HttpStatusCode.OK)
+            {
+                return Enumerable.Empty<string>();
+            }
+
+            return groupResult
+                .toJToken()
+                .SelectToken("member.entity")
+                .Where(x => x.Value<string?>("reference").Contains("Patient/"))
+                .Select(x => x.ToString().Split("/").Last());
+        }
+
+        public IEnumerable<string> BuildDeviceExportRequests(IEnumerable<string> patientIds, string oid)
+        {
+
+            // Encode the patient id into the type filter
+            IEnumerable<string> patientIdsTypeFilters = patientIds.Select(x => HttpUtility.UrlEncode($"Device.patient={x}").Replace(".", "%3F"));
+
+            int baseUrlLength = Utils.GetEnvironmentVariable("FS-URL", "").Length;
+
+            string baseDeviceRequest = $"$export?_container={oid}&_type=Device&_typefilter=";
+            string currentRequestString = baseDeviceRequest;
+
+            foreach (var typeFilter in patientIdsTypeFilters)
+            {
+                // If we are over the max URL Length, return
+                if (baseUrlLength + "/".Length + currentRequestString.Length + ",".Length + typeFilter.Length > MAX_URL_LENGTH)
+                {
+                    yield return currentRequestString;
+                    currentRequestString = baseDeviceRequest;
+                    continue;
+                }
+
+                // Add separator if not first type filter
+                if (currentRequestString.Last() != '=')
+                {
+                    currentRequestString += ",";
+                }
+
+                // Add current typeFilter
+                currentRequestString += typeFilter;
+            }
+
+            if (currentRequestString != baseDeviceRequest)
+            {
+                yield return currentRequestString;
+            }
+        }
     }
 }

--- a/FHIRProxy/preprocessors/ONCExportPreProcess.cs
+++ b/FHIRProxy/preprocessors/ONCExportPreProcess.cs
@@ -103,6 +103,7 @@ namespace FHIRProxy.preprocessors
             var result = groupResult
                 .toJToken()
                 .SelectToken("member.entity")
+                .Where(x => x.Value<string?>("reference") is not null)
                 .Where(x => x.Value<string?>("reference").Contains("Patient/"))
                 .Select(x => x.ToString().Split("/").Last());
 

--- a/FHIRProxy/preprocessors/ONCExportPreProcess.cs
+++ b/FHIRProxy/preprocessors/ONCExportPreProcess.cs
@@ -217,17 +217,17 @@ namespace FHIRProxy.preprocessors
 
                 JToken current = currentResponse.toJToken();
 
-                foreach (JToken singleOutput in current.SelectTokens("output.*"))
+                foreach (JToken singleOutput in current.SelectTokens("output[*]"))
                 {
                     output.Add(singleOutput);
                 }
                 
-                foreach (JToken singleError in current.SelectTokens("error.*"))
+                foreach (JToken singleError in current.SelectTokens("error[*]"))
                 {
                     error.Add(singleError);
                 }
                 
-                foreach (JToken singleIssue in current.SelectTokens("issues.*"))
+                foreach (JToken singleIssue in current.SelectTokens("issues[*]"))
                 {
                     issues.Add(singleIssue);
                 }


### PR DESCRIPTION
Changed ONC Group Export prefilter to:
- intercept group exports
- get list of patients in group and kick off 1+ system level device exports
- kick off a device level export for the referential data (Medication, Organization, Practitioner, Location)
- kick off orig group export
- save all of these into a new table in the proxy table storage
- return a new guid key for this row

On check
- it fetches the table row
- checks all the exports
- combines all the export responses into one
- changes the url so proxy can intercept them