### PR TITLE
Added Aggregate Export Delete Handler

### DIFF
--- a/FHIRProxy/preprocessors/ONCExportPreProcess.cs
+++ b/FHIRProxy/preprocessors/ONCExportPreProcess.cs
@@ -262,7 +262,15 @@ namespace FHIRProxy.preprocessors
             // Kick off deletes to child requests and move on
             foreach (var uri in ea.ExportUrlList.Select(x => new Uri(x)))
             {
-                FHIRResponse currentResponse = await FHIRClient.CallFHIRServer(uri.LocalPath, body: "", "DELETE", log);
+                try
+                {
+                    FHIRResponse currentResponse = await FHIRClient.CallFHIRServer(uri.LocalPath, body: "", "DELETE", log);
+                }
+                catch (Exception)
+                {
+                    // swallow - FHIR Service may return an error here for smaller exports due to timing
+                }
+                
             }
 
             return new FHIRResponse()

--- a/FHIRProxy/preprocessors/ONCExportPreProcess.cs
+++ b/FHIRProxy/preprocessors/ONCExportPreProcess.cs
@@ -84,6 +84,13 @@ namespace FHIRProxy.preprocessors
                 CloudTable eaTable = Utils.getTable(ProxyConstants.EXPORT_AGGREGATE_TABLE);
                 ExportAggregate ea = Utils.getEntity<ExportAggregate>(eaTable, ProxyConstants.EXPORT_AGGREGATE_TABLE, exportId);
 
+                if (ea is null)
+                {
+                    FHIRResponse resp = new();
+                    resp.StatusCode = HttpStatusCode.NotFound;
+                    return new ProxyProcessResult(false, "", requestBody, resp);
+                }
+
                 if (req.Method.Equals("GET"))
                 {
                     FHIRResponse resp = await FetchExportAggregateResult(ea, req.Host, log);
@@ -93,6 +100,7 @@ namespace FHIRProxy.preprocessors
                 if (req.Method.Equals("DELETE"))
                 {
                     FHIRResponse resp = await DeleteExportAggregateResult(ea, log);
+                    Utils.deleteEntity(eaTable, ea);
                     return new ProxyProcessResult(false, "", requestBody, resp);
                 }
             }
@@ -270,7 +278,6 @@ namespace FHIRProxy.preprocessors
                 {
                     // swallow - FHIR Service may return an error here for smaller exports due to timing
                 }
-                
             }
 
             return new FHIRResponse()

--- a/FHIRProxy/preprocessors/ONCExportPreProcess.cs
+++ b/FHIRProxy/preprocessors/ONCExportPreProcess.cs
@@ -259,20 +259,10 @@ namespace FHIRProxy.preprocessors
         public async Task<FHIRResponse> DeleteExportAggregateResult(ExportAggregate ea, ILogger log)
         {
 
+            // Kick off deletes to child requests and move on
             foreach (var uri in ea.ExportUrlList.Select(x => new Uri(x)))
             {
                 FHIRResponse currentResponse = await FHIRClient.CallFHIRServer(uri.LocalPath, body: "", "DELETE", log);
-
-                // If any exports are still running wait
-                if (currentResponse.StatusCode != HttpStatusCode.Accepted)
-                {
-                    if (!currentResponse.IsSuccess())
-                    {
-                        log.LogWarning("Child export delete operation returned unsucessful. {Path} {StatusCode} {Body}", uri.LocalPath, currentResponse.StatusCode, currentResponse.Content.ToString());
-                    }
-
-                    return currentResponse;
-                }
             }
 
             return new FHIRResponse()


### PR DESCRIPTION
Aggregate export delete will:
- Fetch all exports
- Kick off delete on child exports
- Delete export row in table

Also added code to return 404 when checking an export operation that does not exist